### PR TITLE
custom query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /checkouts
 /classes
 /target
+/.idea
+*.iml


### PR DESCRIPTION
This allows a map of additional query params to be passed in the options map to `aws-simple-sign.core/generate-presigned-url`.

My use case for this is explicitly telling s3 which content-type to put in the response headers, though I've kept it generic in case there are others.